### PR TITLE
REM-11151: add condominium context

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,5 @@ Context | Description
 [Sedex](sedex.md) | Allows clients to send and receive Sedex-Messages
 [Tenancy Application](tenancy_application_context.md)| Events related to tenancy applications
 [Tenant Portal](tenant_portal.md)| Events that occur on a Tenant Portal
+[Condominium Application](tenancy_application_context.md)| Events related to condominium applications
 [Thirdparty Notification](thirdparty_notification.md) | Events that related to a Thirdparty Notification. This events are issued by the Thirdparty Notification Service (Drittmeldung Service)

--- a/condominium_context.md
+++ b/condominium_context.md
@@ -1,0 +1,122 @@
+# Condominium Context
+
+## Events
+
+Type | GARAIO REM | REM | Description
+---|---|---|---
+[`Condominium.Ownership.Created`](#condominiumownershipcreated) | :heavy_check_mark: | :x: | A condominium ownership was added to the system
+[`Condominium.Ownership.Updated`](#condominiumownershipupdated) | :heavy_check_mark: | :x: | Some condominium data was updated
+[`Condominium.Ownership.Deleted`](#condominiumownershipdeleted) | :heavy_check_mark: | :x: | A condominium ownership has been deleted
+
+### `Condominium.Ownership.Created`
+
+Field | Type | Content / Remarks
+---|---|---
+`eventType` | `string` | `Condominium.Ownership.Created`
+`data` | `hash` |
+&nbsp;&nbsp;`startDate` | `string` | ISO 8601 encoded date, e.g. `2019-05-25`
+&nbsp;&nbsp;`unitReference` | `string` | unique unit identifier, e.g. `234.01.0001`
+&nbsp;&nbsp;`owner` | `hash` |
+&nbsp;&nbsp;&nbsp;&nbsp;`reference` | `string` | owner reference; uniquely identifies a person
+&nbsp;&nbsp;&nbsp;&nbsp;`salutationLines` | `array` of `string` | This field contains a list of salutations. This might not correspond to the amount of `nameLines`. |
+&nbsp;&nbsp;&nbsp;&nbsp;`nameLines` | `array` of `string` | This field contains a list of names. This might not correspond to the amount of `salutationLines`. |
+&nbsp;&nbsp;&nbsp;&nbsp;`languageCode` | `string` | `de`, `fr`, `it` or `en`
+&nbsp;&nbsp;&nbsp;&nbsp;`nationalityCode` | `string` | ISO country code, e.g. `CH`
+&nbsp;&nbsp;&nbsp;&nbsp;`phoneNumber` | `string` | might be `null`
+&nbsp;&nbsp;&nbsp;&nbsp;`email` | `string` | might be `null`
+
+#### Example
+
+```json
+{"eventType":"Condominium.Ownership.Created",
+  "data":{
+    "accessionDate":"2019-05-01",
+    "effectiveAccessionDate":"2019-05-01",
+    "unitReference":"10001.786.29",
+    "owner":{
+      "reference":"100004",
+      "salutationLines":[
+        "Sehr geehrter Herr Mustermann"
+      ],
+      "nameLines":[
+        "Hans Mustermann",
+        "Erika Mustermann"
+      ],
+      "languageCode":"de",
+      "nationalityCode":"AT",
+      "phoneNumber":"+41 31 331 21 11",
+      "email":"email@test-mail.xy"
+    }
+  }
+}
+```
+
+### `Condominium.Ownership.Updated`
+
+Field | Type | Content / Remarks
+---|---|---
+`eventType` | `string` | `Condominium.Ownership.Updated`
+`data` | `hash` |
+&nbsp;&nbsp;`startDate` | `string` | ISO 8601 encoded date, e.g. `2019-05-25`
+&nbsp;&nbsp;`unitReference` | `string` | unique unit identifier, e.g. `234.01.0001`
+&nbsp;&nbsp;`owner` | `hash` |
+&nbsp;&nbsp;&nbsp;&nbsp;`reference` | `string` | owner reference; uniquely identifies a person
+&nbsp;&nbsp;&nbsp;&nbsp;`salutationLines` | `array` of `string` | This field contains a list of salutations. This might not correspond to the amount of `nameLines`. |
+&nbsp;&nbsp;&nbsp;&nbsp;`nameLines` | `array` of `string` | This field contains a list of names. This might not correspond to the amount of `salutationLines`. |
+&nbsp;&nbsp;&nbsp;&nbsp;`languageCode` | `string` | `de`, `fr`, `it` or `en`
+&nbsp;&nbsp;&nbsp;&nbsp;`nationalityCode` | `string` | ISO country code, e.g. `CH`
+&nbsp;&nbsp;&nbsp;&nbsp;`phoneNumber` | `string` | might be `null`
+&nbsp;&nbsp;&nbsp;&nbsp;`email` | `string` | might be `null`
+
+#### Example
+
+```json
+{"eventType":"Condominium.Ownership.Updated",
+  "data":{
+    "accessionDate":"2019-05-01",
+    "effectiveAccessionDate":"2019-05-01",
+    "unitReference":"10001.786.29",
+    "owner":{
+      "reference":"100004",
+      "salutationLines":[
+        "Sehr geehrter Herr Mustermann"
+      ],
+      "nameLines":[
+        "Hans Mustermann",
+        "Erika Mustermann"
+      ],
+      "languageCode":"de",
+      "nationalityCode":"AT",
+      "phoneNumber":"+41 31 331 21 11",
+      "email":"email@test-mail.xy"
+    }
+  }
+}
+```
+
+### `Condominium.Ownership.Deleted`
+
+Field | Type | Content / Remarks
+---|---|---
+`eventType` | `string` | `Condominium.Ownership.Deleted`
+`data` | `hash` |
+&nbsp;&nbsp;`unitReference` | `string` | unique unit identifier, e.g. `234.01.0001`, might be `null`
+&nbsp;&nbsp;`startDate` | `string` | ISO 8601 encoded date, e.g. `2019-05-25`
+&nbsp;&nbsp;`endDate` | `string` | ISO 8601 encoded date, e.g. `2019-05-25`
+&nbsp;&nbsp;`owner` | `hash` |
+&nbsp;&nbsp;&nbsp;&nbsp;`reference` | `string` | owner reference; uniquely identifies a person
+
+#### Example
+
+```json
+{"eventType":"Condominium.Ownership.Deleted",
+  "data":{
+    "unitReference":"10001.786.29",
+    "startDate":"2021-04-08",
+    "endDate":"2021-04-08",
+    "owner":{
+      "reference":"100010"
+    }
+  }
+}
+```

--- a/tenancy_application_context.md
+++ b/tenancy_application_context.md
@@ -18,7 +18,7 @@ Field | Type | Content / Remarks
 `eventType` | `string` | `TenancyApplication.Dossier.Selected`
 `data` | `hash` |
 &nbsp;&nbsp;`dossierId` | `string` | Unique identifier within the tenancy application platform |
-&nbsp;&nbsp;`unitReference` | ``string`` | `String` referencing an existing unit in the target GARAIO REM |
+&nbsp;&nbsp;`unitReference` | `string` | `String` referencing an existing unit in the target GARAIO REM |
 &nbsp;&nbsp;`requestedMovingDate` | `string` | ISO 8601 encoded date, eg `'1980-02-17'`; might be null |
 &nbsp;&nbsp;`applicants` | `array` | list of applicants; must contain at least one applicant |
 &nbsp;&nbsp;&nbsp;&nbsp;`address` | `hash` | address data for this applicant; might be null |


### PR DESCRIPTION
I don't know whether REM1 also had this information published. [I've set it to `x` now](https://github.com/alexanderadam/remcloud-message-bus-api/blob/topic/REM-11151-add-Condominium-Context/condominium_context.md#events).